### PR TITLE
Allow running the script from any subdirectory

### DIFF
--- a/git-diff-blame
+++ b/git-diff-blame
@@ -15,6 +15,11 @@ sub get_blame_prefix {
 	return $1;
 }
 
+$git_root = `git rev-parse --show-toplevel`;
+$git_root =~ s/^\s+//;
+$git_root =~ s/\s+$//;
+chdir($git_root) or die "$!";
+
 my ($oldrev, $newrev) = @ARGV;
 $oldrev ||= 'HEAD';
 if ($newrev) {


### PR DESCRIPTION
The script assumes it is running from the root of the repository. This change allows using the script from any subdirectory as well.
