### PR TITLE
Add public domain license header from upstream

### DIFF
--- a/git-diff-blame
+++ b/git-diff-blame
@@ -1,4 +1,11 @@
 #!/usr/bin/perl -w
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
 
 sub parse_hunk_header {
 	my ($line) = @_;


### PR DESCRIPTION
Source: https://github.com/toddlipcon/tlipcon-bin/commit/d12ff5939e23a0066fd1d6eff6f53a639d177bbc

Should also be added to the README and/or a LICENSE file, if accepted.
